### PR TITLE
Fix ambiguous python shebangs

### DIFF
--- a/eucalyptus-imaging-worker
+++ b/eucalyptus-imaging-worker
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 #
 # Copyright 2009-2014 Eucalyptus Systems, Inc.
 #

--- a/eucalyptus-imaging-worker.spec
+++ b/eucalyptus-imaging-worker.spec
@@ -46,6 +46,7 @@ rm -rf $RPM_BUILD_ROOT
 
 # Install CLI tools
 %{__python} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
+sed --in-place '1s/python /python2 /' $RPM_BUILD_ROOT/usr/bin/eucalyptus-imaging-worker
 
 #
 # There is no extension on the installed sudoers file for a reason

--- a/scripts/worker-ntp-update
+++ b/scripts/worker-ntp-update
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 #
 # Copyright 2009-2014 Eucalyptus Systems, Inc.
 #


### PR DESCRIPTION
Fix ambiguous python shebangs as these can otherwise cause build failures.

Example packaging guidelines covering python 2 use:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_multiple_python_runtimes

Build:  ocd/job/eucalyptus-internal-5-build-random-rpms/57/
QA run: ocd/job/eucalyptus-5-qa-suite/55/