### PR TITLE
Update block device count check to allow for instance types with root device only

### DIFF
--- a/eucaimgworker/main_loop.py
+++ b/eucaimgworker/main_loop.py
@@ -109,9 +109,9 @@ def start_worker():
         logger.error('failed to load floppy driver')
     try:
         res = get_block_devices()
-        if len(res) != 2:
+        if len(res) > 2:
             logger.error(
-                "Found %d block device(s). Imaging VM (re)started in a very small type or with volume(s) attached" % len(
+                "Found %d block device(s). Imaging VM (re)started with volume(s) attached?" % len(
                     res))
             sys.exit(1)
         res.sort(reverse=True)


### PR DESCRIPTION
The imaging worker should not refuse to start on instances with a single block device as a sufficiently large root device is sufficient for correct operation.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=637
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/100/
Test: /job/eucalyptus-5-qa-suite/192/

Demo is that import tasks (e.g. `euca-import-volume`) are now processed when using instance-types without additional ephemeral disk.